### PR TITLE
fix: handle Object-based entry settings (multi-entries)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "dependencies": {
     "react-dev-utils": "^5.0.0",
     "react-error-overlay": "^4.0.0"
+  },
+  "peerDependencies": {
+    "webpack": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,16 @@ import errorOverlayMiddleware from 'react-dev-utils/errorOverlayMiddleware'
 
 class ErrorOverlayPlugin {
   apply(compiler) {
+    const className = this.constructor.name
+
     if (compiler.options.mode !== 'development') return
 
-    compiler.hooks.entryOption.tap('TestPlugin', (context, entry) => {
-      entry.unshift(require.resolve('./entry'))
+    compiler.hooks.entryOption.tap(className, (context, entry) => {
+      const chunkPath = require.resolve('./entry')
+      adjustEntry(entry, chunkPath)
     })
 
-    compiler.hooks.afterResolvers.tap('TestPlugin', ({ options }) => {
+    compiler.hooks.afterResolvers.tap(className, ({ options }) => {
       if (options.devServer) {
         const originalBefore = options.devServer.before
         options.devServer.before = app => {
@@ -20,6 +23,27 @@ class ErrorOverlayPlugin {
       }
     })
   }
+}
+
+function adjustEntry(entry, chunkPath) {
+  if (typeof entry === 'string') {
+    throw new Error(
+      `We currently do not inject our entry code into single-file anonymous entries.
+Please use a multi-main (array) or object-form \`entry\` setting for now.`,
+    )
+  }
+
+  if (Array.isArray(entry)) {
+    if (!entry.includes(chunkPath)) {
+      entry.unshift(chunkPath)
+    }
+  } else {
+    Object.entries(entry).forEach(([entryName, entryDesc]) => {
+      entry[entryName] = adjustEntry(entryDesc, chunkPath)
+    })
+  }
+
+  return entry
 }
 
 export default ErrorOverlayPlugin


### PR DESCRIPTION
Anonymous, single-String entries are not covered yet. Couldn't find a way to turn the existing entry into an Array entry cleanly.  Such entries result in explicit error throwing.

Fixes #4