### PR TITLE
fix: syntax error in IE

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,5 @@
       }
     ]
   ],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-es2015-arrow-functions"]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.2",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "conventional-github-releaser": "^2.0.0",

--- a/src/entry.js
+++ b/src/entry.js
@@ -20,7 +20,7 @@ setEditorHandler(errorLocation => {
 })
 
 startReportingRuntimeErrors({
-  onError() {
+  onError: function() {
     module.hot.addStatusHandler(status => {
       if (status === 'apply') {
         window.location.reload()


### PR DESCRIPTION
This fixes issue #13. 

I have added `transform-es2015-arrow-functions` which transforms arrow functions into ES5 functions. 
I have also fixed another syntax error which occured in IE.

The overlay still does not work properly in IE but at least it does not in itself throw errors and stop execution of other resources.