### PR TITLE
Add devtool option to README sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module.exports = {
     filename: 'bundle.js',
   },
   plugins: [new ErrorOverlayPlugin()],
+  devtool: 'cheap-module-source-map', // 'eval' is not supported by error-overlay-webpack-plugin
 }
 ```
 


### PR DESCRIPTION
Following from https://github.com/smooth-code/error-overlay-webpack-plugin/issues/8#issuecomment-404101038, I think this is a common enough issue that it's worth adding it to the README.

I'd be interested to know why this is the case so it can be added as a caveat.