### PR TITLE
fix: pass in compiler to devServer before()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ class ErrorOverlayPlugin {
         const originalBefore = options.devServer.before
         options.devServer.before = (app, server) => {
           if (originalBefore) {
-            originalBefore(app, server)
+            originalBefore(app, server, compiler)
           }
           app.use(errorOverlayMiddleware())
         }


### PR DESCRIPTION
The [`devServer.before()`](https://webpack.js.org/configuration/dev-server/#devserverbefore) API accepts three arguments: `app`, `server`, and `compiler`. When overriding this function, though, `error-overlay-webpack-plugin` only passes in the first two arguments, which can lead to exceptions when other `before` functions try to access `compiler`. This fixes that.