### PR TITLE
chore: add type def for the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/sponsors/gregberge"
   },
   "scripts": {
-    "build": "rm -rf ./dist && rollup -c && cp -r ./src/entries ./dist/entries",
+    "build": "rm -rf ./dist && rollup -c && cp -r ./src/entries ./dist/entries && cp ./src/index.d.ts ./dist",
     "format": "prettier --write \"**/*.{js,json,md}\" \"*.{js,json,md}\"",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,13 @@
+export = ErrorOverlayPlugin;
+
+type Compiler = import("webpack").Compiler;
+
+declare class ErrorOverlayPlugin {
+  apply(compiler: Compiler): void;
+}
+
+declare const pluginName = 'error-overlay-webpack-plugin';
+
+declare namespace ErrorOverlayPlugin {
+  export { pluginName };
+}


### PR DESCRIPTION
Adds type definitions for the plugin. Resolves [#101](https://github.com/gregberge/error-overlay-webpack-plugin/issues/101)