### PR TITLE
fix: 404 errors that show up in the console when Webpack 5 is using WebSocket instead of SockJS

### DIFF
--- a/src/entries/devserver.mjs
+++ b/src/entries/devserver.mjs
@@ -10,13 +10,22 @@ if (typeof __resourceQuery === 'string' && __resourceQuery) {
   sockOptions = querystring.parse(__resourceQuery.substr(1))
 }
 
-const connection = new SockJS(
-  `${window.location.protocol}//${
-    sockOptions.sockHost || window.location.hostname
-  }:${sockOptions.sockPort || window.location.port}${
-    sockOptions.sockPath || '/sockjs-node'
-  }`,
-)
+const connection =
+  sockOptions.sockPath === '/ws' && typeof WebSocket !== 'undefined'
+    ? new WebSocket(
+        `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${
+          sockOptions.sockHost || window.location.hostname
+        }:${sockOptions.sockPort || window.location.port}${
+          sockOptions.sockPath || '/ws'
+        }`,
+      )
+    : new SockJS(
+        `${window.location.protocol}//${
+          sockOptions.sockHost || window.location.hostname
+        }:${sockOptions.sockPort || window.location.port}${
+          sockOptions.sockPath || '/sockjs-node'
+        }`,
+      )
 
 connection.onmessage = function onmessage(e) {
   const { type, data } = JSON.parse(e.data)


### PR DESCRIPTION
These errors show up when using the latest version of Webpack 5.
`create-react-app` is also using WebSocket now ([link](https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/webpackHotDevClient.js#L60))

Closes #96

## Before this PR
<img width="696" alt="Screenshot 2022-11-10 at 20 48 54" src="https://user-images.githubusercontent.com/7817232/201181003-6d58e56e-f499-4f42-9ba6-fb88c8cefac8.png">

## After this PR
<img width="696" alt="image" src="https://user-images.githubusercontent.com/7817232/201181427-b01b0d45-373f-48ca-a855-1701b8e03460.png">
